### PR TITLE
Add default community files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,64 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to
+making participation in our project and our community a harassment-free experience for everyone,
+regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and
+are expected to take appropriate and fair corrective action in response to any instances of
+unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments,
+commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct,
+or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual
+is representing the project or its community. Examples of representing a project or community
+include using an official project e-mail address, posting via an official social media account,
+or acting as an appointed representative at an online or offline event. Representation of a project
+may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting
+the project team members.
+The project team will review and investigate all complaints,
+and will respond in a way that it deems appropriate to the circumstances.
+The project team is obligated to maintain confidentiality with regard to the
+reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may
+face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing
+
+When contributing a non-obvious change, please first
+discuss the change you wish to make via issue or slack, or any other
+method with the owners of this repository before making a change.
+
+Please follow the [code of conduct](CODE_OF_CONDUCT.md) in all your interactions with the project.
+
+## Prerequisites
+
+* It is strongly recommended that you use OSX or popular Linux distributions systems e.g. Ubuntu, Redhat, or OpenSUSE for development.

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,41 @@
+<!--
+Template relevant to bug reports only!
+
+Keep issue title verbose enough and add prefix telling
+about what components it touches e.g "query:" or ".*:"
+-->
+
+**Versions of relevant software used**
+
+**What happened**
+
+**What you expected to happen**
+
+**How to reproduce it (as minimally and precisely as possible)**:
+
+**Full logs to relevant components**
+
+<!--
+Uncomment if you would like to post collapsible logs:
+
+<details>Logs
+<p>
+
+```
+```
+
+</p>
+</details>
+-->
+
+**Anything else we need to know**
+
+<!--
+Uncomment and fill if you use not casual environment or if it might be relevant.
+
+**Environment**:
+- OS (e.g. from /etc/os-release):
+- Kernel (e.g. `uname -a`):
+- Others:
+
+-->

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+<!--
+    Keep PR title verbose enough and add prefix telling
+    about what components it touches e.g "query:" or ".*:"
+-->
+
+## Changes
+
+<!-- Enumerate changes you made -->
+
+## Verification
+
+<!-- How you tested it? How do you know it works? -->


### PR DESCRIPTION
Adding a default set of community files for the org.

Note that these will take effect in repos that do not have their own more specific file (ie - Thanos won't be affected because it's already got these - in fact, I more or less just copied the Thanos files, stripped out the specific Thanos references, and opened this PR).